### PR TITLE
Revert to Alpine 3.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  ALPINE_VERSION: 3.17.0
+  ALPINE_VERSION: 3.16.0
   DOCKER_BUILDKIT: 1
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ALPINE_VERSION ?= 3.17.0
+ALPINE_VERSION ?= 3.16.0
 REPO_VERSION ?= $(shell echo "$(ALPINE_VERSION)" | sed -E 's/^([0-9]+\.[0-9]+).*/v\1/')
 GIT_TAG ?= $(shell echo "v$(ALPINE_VERSION)" | sed 's/^vedge$$/origin\/master/')
 BUILD_ID ?= $(shell git describe --tags)

--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -221,6 +221,8 @@ if [ "${LIMA_INSTALL_CNI_PLUGIN_FLANNEL}" == "true" ]; then
     if [ "$(uname -m)" == "aarch64" ]; then
         ARCH=arm64
     fi
+    mkdir -p "${tmp}/usr/libexec/cni"
+    ln -s "flannel-${ARCH}" "${tmp}/usr/libexec/cni/flannel"
 fi
 
 if [ "${LIMA_INSTALL_CURL}" == "true" ]; then


### PR DESCRIPTION
Alpine 3.17 ISOs for aarch64 cannot be loaded by Apple's Virtualization Framework (see https://github.com/lima-vm/lima/issues/1399 and https://gitlab.alpinelinux.org/alpine/aports/-/issues/14407).

This PR temporarily reverts Alpine back to 3.16 until the root issue has been resolved.