### PR TITLE
Create a mount script instead of editing /etc/fstab

### DIFF
--- a/lima-init.sh
+++ b/lima-init.sh
@@ -37,10 +37,10 @@ LIMA_CIDATA_GID=$(id -g "${LIMA_CIDATA_USER}")
 chown -R "${LIMA_CIDATA_UID}:${LIMA_CIDATA_GID}" "${LIMA_CIDATA_SSHDIR}"
 chmod 600 "${LIMA_CIDATA_SSHDIR}"/authorized_keys
 
-# Add mounts to /etc/fstab
-sed -i '/#LIMA-START/,/#LIMA-END/d' /etc/fstab
-echo "#LIMA-START" >> /etc/fstab
-awk -f- "${LIMA_CIDATA_MNT}"/user-data <<'EOF' >> /etc/fstab
+# Process mounts
+MOUNT_SCRIPT=/etc/lima-mounts
+echo "#!/bin/sh -eux" >"${MOUNT_SCRIPT}"
+awk -f- "${LIMA_CIDATA_MNT}"/user-data <<'EOF' >>"${MOUNT_SCRIPT}"
 /^mounts:/ {
     flag = 1
     next
@@ -49,15 +49,17 @@ awk -f- "${LIMA_CIDATA_MNT}"/user-data <<'EOF' >> /etc/fstab
     flag = 0
 }
 flag {
+    # Use a pattern unlikely to appear in a filename. "\0" unfortunately doesn't work.
+    FS = "<;><><;>"
     sub(/^ *- \[/, "")
     sub(/"?\] *$/, "")
-    gsub("\"?, \"?", "\t")
-    print $0
+    gsub("\"?, \"?", FS)
+    printf "mkdir -p \"%s\"\n", $2
+    printf "mount -t %s -o \"%s\" %s \"%s\"\n", $3, $4, $1, $2
 }
 EOF
-echo "#LIMA-END" >> /etc/fstab
-mkmntdirs
-mount -a
+chmod +x "${MOUNT_SCRIPT}"
+"${MOUNT_SCRIPT}"
 
 # Rename network interfaces according to network-config setting
 mkdir -p /var/lib/lima-init


### PR DESCRIPTION
This enables support for mount points that include spaces. `/etc/fstab` normally supports encoding special characters in filenames using octal constants (like "\040` for a space), but that doesn't work on Alpine.

```console
$ l shell rd ls /Applications/Rancher\ Desktop.app/Contents/Resources/resources
darwin             icons              linux              preload.js         rancher-dashboard  rdx-proxy.tgz

$ l shell rd cat /etc/lima-mounts
#!/bin/sh -eux
mkdir -p "/Users/jan"
mount -t 9p -o "ro,trans=virtio,version=9p2000.L,msize=131072,cache=fscache,nofail" mount0 "/Users/jan"
mkdir -p "/Volumes/ThunderBlade"
mount -t 9p -o "rw,trans=virtio,version=9p2000.L,msize=131072,cache=mmap,nofail" mount1 "/Volumes/ThunderBlade"
mkdir -p "/tmp/lima"
mount -t 9p -o "rw,trans=virtio,version=9p2000.L,msize=131072,cache=mmap,nofail" mount2 "/tmp/lima"
mkdir -p "/Applications/Rancher Desktop.app/Contents/Resources/resources"
mount -t 9p -o "rw,trans=virtio,version=9p2000.L,msize=131072,cache=mmap,nofail" mount3 "/Applications/Rancher Desktop.app/Contents/Resources/resources"
```