### PR TITLE
Downgrade to buildkit 0.11.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /rd.yaml
 /std.yaml
 /nerdctl-*
+/buildkit-*
 /openresty-*
 /qemu-*
 /cri-dockerd-*

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ ARCH_ALIAS_aarch64 = arm64
 ARCH_ALIAS = $(shell echo "$(ARCH_ALIAS_$(ARCH))")
 
 NERDCTL_VERSION=1.5.0
+BUILDKIT_VERSION=0.11.6
 QEMU_VERSION=v7.0.0
 CRI_DOCKERD_VERSION=0.2.6
 CRI_DOCKERD_ORG=Mirantis
@@ -42,19 +43,27 @@ mkimage: openresty-v$(OPENRESTY_VERSION)-$(ARCH).tar
 		.
 
 .PHONY: iso
-iso: nerdctl-full-$(NERDCTL_VERSION)-$(ARCH) qemu-$(QEMU_VERSION)-copying cri-dockerd-$(CRI_DOCKERD_VERSION)-$(ARCH)
-	ALPINE_VERSION=$(ALPINE_VERSION) NERDCTL_VERSION=$(NERDCTL_VERSION) QEMU_VERSION=$(QEMU_VERSION) CRI_DOCKERD_VERSION=$(CRI_DOCKERD_VERSION) REPO_VERSION=$(REPO_VERSION) EDITION=$(EDITION) BUILD_ID=$(BUILD_ID) ARCH=$(ARCH) ARCH_ALIAS=$(ARCH_ALIAS) ./build.sh
+iso:
+	ALPINE_VERSION=$(ALPINE_VERSION) NERDCTL_VERSION=$(NERDCTL_VERSION) BUILDKIT_VERSION=$(BUILDKIT_VERSION) QEMU_VERSION=$(QEMU_VERSION) CRI_DOCKERD_VERSION=$(CRI_DOCKERD_VERSION) REPO_VERSION=$(REPO_VERSION) EDITION=$(EDITION) BUILD_ID=$(BUILD_ID) ARCH=$(ARCH) ARCH_ALIAS=$(ARCH_ALIAS) ./build.sh
 
 
+iso: nerdctl-full-$(NERDCTL_VERSION)-$(ARCH)
 nerdctl-full-$(NERDCTL_VERSION)-$(ARCH):
 	curl -o $@ -Ls https://github.com/containerd/nerdctl/releases/download/v$(NERDCTL_VERSION)/nerdctl-full-$(NERDCTL_VERSION)-linux-$(ARCH_ALIAS).tar.gz
 
+iso: buildkit-v$(BUILDKIT_VERSION)-$(ARCH).tar.gz
+buildkit-v$(BUILDKIT_VERSION)-$(ARCH).tar.gz:
+	curl -o $@ -Ls https://github.com/moby/buildkit/releases/download/v$(BUILDKIT_VERSION)/buildkit-v$(BUILDKIT_VERSION).linux-$(ARCH_ALIAS).tar.gz
+
+iso: openresty-v$(OPENRESTY_VERSION)-$(ARCH).tar
 openresty-v$(OPENRESTY_VERSION)-$(ARCH).tar:
 	curl -o $@ -Ls https://github.com/rancher-sandbox/openresty-packaging/releases/download/v$(OPENRESTY_VERSION)/$@
 
+iso: qemu-$(QEMU_VERSION)-copying
 qemu-$(QEMU_VERSION)-copying:
 	curl -o $@ -Ls https://raw.githubusercontent.com/qemu/qemu/$(QEMU_VERSION)/COPYING
 
+iso: cri-dockerd-$(CRI_DOCKERD_VERSION)-$(ARCH)
 cri-dockerd-$(CRI_DOCKERD_VERSION)-$(ARCH):
 	curl -o $@ -Ls https://github.com/$(CRI_DOCKERD_ORG)/cri-dockerd/releases/download/v$(CRI_DOCKERD_VERSION)/cri-dockerd-$(CRI_DOCKERD_VERSION).$(ARCH_ALIAS).tgz
 	curl -o $@.LICENSE -Ls https://raw.githubusercontent.com/$(CRI_DOCKERD_ORG)/cri-dockerd/v$(CRI_DOCKERD_VERSION)/LICENSE

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,7 @@ ${DOCKER} run --rm \
     -v "${PWD}/lima-init-local.openrc:/home/build/lima-init-local.openrc:ro" \
     -v "${PWD}/lima-network.awk:/home/build/lima-network.awk:ro" \
     -v "${PWD}/nerdctl-full-${NERDCTL_VERSION}-${ARCH}:/home/build/nerdctl-full.tar.gz:ro" \
+    -v "${PWD}/buildkit-v${BUILDKIT_VERSION}-${ARCH}.tar.gz:/home/build/buildkit.tar.gz:ro" \
     -v "${PWD}/qemu-${QEMU_VERSION}-copying:/home/build/qemu-copying:ro" \
     -v "${PWD}/cri-dockerd-${CRI_DOCKERD_VERSION}-${ARCH}:/home/build/cri-dockerd.tar.gz:ro" \
     -v "${PWD}/cri-dockerd-${CRI_DOCKERD_VERSION}-${ARCH}.LICENSE:/home/build/cri-dockerd.license:ro" \

--- a/genapkovl-lima.sh
+++ b/genapkovl-lima.sh
@@ -279,6 +279,15 @@ if [ "${LIMA_INSTALL_NERDCTL_FULL}" == "true" ]; then
         cp "${tmp}/nerdctl/bin/${bin}" "${tmp}/usr/local/bin/${bin}"
         chmod u+s "${tmp}/usr/local/bin/${bin}"
     done
+
+    if [ -r /home/build/buildkit.tar.gz ]; then
+        mkdir -p "${tmp}/buildkit"
+        tar xz -C "${tmp}/buildkit" -f /home/build/buildkit.tar.gz
+        for bin in "${tmp}/buildkit/bin"/* ; do
+            cp "${bin}" "${tmp}/usr/local/bin/${bin##*/}"
+            chmod u+s "${tmp}/usr/local/bin/${bin##*/}"
+        done
+    fi
     if [ "${LIMA_INSTALL_NERDCTL_LIBEXEC}" == "true" ]; then
         LIBEXEC=/usr/local/libexec/nerdctl
         mkdir -p "${tmp}${LIBEXEC}"


### PR DESCRIPTION
Buildkit 0.12.0 has issues with OpenRC + hybrid cgroups; see https://github.com/moby/buildkit/issues/4108