### PR TITLE
Fetch docker and prerequisites from the edge repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN \
   mkdir -p /home/build/packages/lima/${ARCH} && \
   cd /home/build/packages/lima/${ARCH} && \
   apk fetch mkcert --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing && \
+  apk fetch docker --no-cache --recursive --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community && \
   apk index -o APKINDEX.tar.gz *.apk && \
   abuild-sign APKINDEX.tar.gz
 


### PR DESCRIPTION
Because 3.18 is now significantly out-of-date.

The following packages are installed from `edge`:

```
#18 7.120 Downloading busybox-1.36.1-r5
#18 7.159 Downloading busybox-binsh-1.36.1-r5
#18 7.166 Downloading ca-certificates-20230506-r0
#18 7.188 Downloading containerd-1.7.8-r0
#18 8.725 Downloading device-mapper-libs-2.03.21-r3
#18 9.784 Downloading docker-24.0.7-r0
#18 9.790 Downloading docker-cli-24.0.7-r0
#18 9.968 Downloading docker-cli-buildx-0.11.2-r3
#18 11.49 Downloading docker-engine-24.0.7-r0
#18 11.96 Downloading iptables-1.8.9-r2
#18 13.03 Downloading libcrypto3-3.1.4-r0
#18 13.07 Downloading libmnl-1.0.5-r1
#18 13.08 Downloading libnftnl-1.2.5-r1
#18 13.08 Downloading libseccomp-2.5.4-r2
#18 13.09 Downloading musl-1.2.4-r2
#18 13.11 Downloading runc-1.1.10-r0
#18 13.18 Downloading tini-static-0.19.0-r2
```