### PR TITLE
build.sh: Use host keys on build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,7 @@ ${DOCKER} run --rm \
     --tag "${TAG}" \
     --outdir /iso \
     --arch "${ARCH}" \
+    --hostkeys \
     --repository "/home/build/packages/lima" \
     --repository "http://dl-cdn.alpinelinux.org/alpine/${REPO_VERSION}/main" \
     --repository "http://dl-cdn.alpinelinux.org/alpine/${REPO_VERSION}/community" \


### PR DESCRIPTION
Since we set up a temporary repository for rd-openresty, we need to tell the build to use host keys (that we installed in mkimage).

See relevant changes in `mkimage.sh`:
https://gitlab.alpinelinux.org/alpine/aports/-/commit/5147450891cc9db4c2615b7c0ac4b978bd3797c8