### PR TITLE
Dockerfile: strip exploit-path modules to block CVE-2026-43284, CVE-2026-43500, CVE-2026-31431

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,17 @@ RUN \
 # Remove --no-chown which is deprecated in apk 3.0 as alias for --usermode (disallowed as root)
 RUN sed -i 's/--initdb --no-chown/--initdb/' /home/build/aports/scripts/mkimage.sh
 
-# Strip kernel modules used only as exploit paths (CVE-2026-43284 dirtyfrag
-# esp4/esp6; CVE-2026-43500 dirtyfrag rxrpc; CVE-2026-31431 copy.fail
-# algif_aead). update-kernel has no exclude flag, so we delete the .ko files
-# from $ROOTFS before the cp -a into $MODLOOP, then re-run depmod to keep
-# modules.dep consistent.
-RUN sed -i 's|^cp -a $ROOTFS/lib/modules $MODLOOP$|find "$ROOTFS/lib/modules/$KVER/kernel" \\( -name "esp4.ko*" -o -name "esp6.ko*" -o -name "rxrpc.ko*" -o -name "algif_aead.ko*" \\) -delete\n$MOCK depmod -b $ROOTFS "$KVER"\n&|' /usr/sbin/update-kernel
+# Strip kernel modules that are unused in the VM but expose known CVEs
+# (CVE-2026-43284 dirtyfrag esp4/esp6; CVE-2026-43500 dirtyfrag rxrpc;
+# CVE-2026-31431 copy.fail algif_aead). update-kernel has no exclude
+# flag, so we inject a hook before its `cp -a ... $MODLOOP` line; depmod
+# re-runs to keep modules.dep consistent.
+RUN cat > /usr/local/lib/strip-exploit-modules.sh <<'EOF'
+for mod in esp4 esp6 rxrpc algif_aead; do
+    find "$ROOTFS/lib/modules/$KVER/kernel" -name "$mod.ko*" -delete
+done
+$MOCK depmod -b "$ROOTFS" "$KVER"
+EOF
+RUN sed -i 's|^cp -a $ROOTFS/lib/modules $MODLOOP$|. /usr/local/lib/strip-exploit-modules.sh\n&|' /usr/sbin/update-kernel
 WORKDIR /home/build/aports/scripts
 ENTRYPOINT ["sh", "./mkimage.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,12 @@ RUN \
 
 # Remove --no-chown which is deprecated in apk 3.0 as alias for --usermode (disallowed as root)
 RUN sed -i 's/--initdb --no-chown/--initdb/' /home/build/aports/scripts/mkimage.sh
+
+# Strip kernel modules used only as exploit paths (CVE-2026-43284 dirtyfrag
+# esp4/esp6; CVE-2026-43500 dirtyfrag rxrpc; CVE-2026-31431 copy.fail
+# algif_aead). update-kernel has no exclude flag, so we delete the .ko files
+# from $ROOTFS before the cp -a into $MODLOOP, then re-run depmod to keep
+# modules.dep consistent.
+RUN sed -i 's|^cp -a $ROOTFS/lib/modules $MODLOOP$|find "$ROOTFS/lib/modules/$KVER/kernel" \\( -name "esp4.ko*" -o -name "esp6.ko*" -o -name "rxrpc.ko*" -o -name "algif_aead.ko*" \\) -delete\n$MOCK depmod -b $ROOTFS "$KVER"\n&|' /usr/sbin/update-kernel
 WORKDIR /home/build/aports/scripts
 ENTRYPOINT ["sh", "./mkimage.sh"]


### PR DESCRIPTION
# Dockerfile: strip exploit-path modules to block CVE-2026-43284, CVE-2026-43500, CVE-2026-31431

Patches alpine-conf's `update-kernel` to remove four kernel modules from the modloop squashfs before `mksquashfs` runs:

| Module          | Exploit                      | Mechanism                                  |
| --------------- | ---------------------------- | ------------------------------------------ |
| `esp4` / `esp6` | dirtyfrag (CVE-2026-43284)   | XFRM ESP page-cache write primitive        |
| `rxrpc`         | dirtyfrag (CVE-2026-43500)   | AF_RXRPC path via `pcbc(fcrypt)`           |
| `algif_aead`    | copy.fail (CVE-2026-31431)   | AF_ALG AEAD in-place page-cache write      |

Without these modules the exploits cannot obtain a page-cache write primitive, protecting k3s pods and unprivileged VM processes that are not covered by the container seccomp profile.

## Why these modules are safe to remove

None of them serves a purpose inside the Lima / Rancher Desktop VM:

- **`esp4` / `esp6`** implement IPsec ESP, used for site-to-site VPN gateways (e.g. strongSwan) — not a role the VM plays.
- **`rxrpc`** implements the RxRPC protocol, used almost exclusively by AFS (Andrew File System) — not present in any RD workload. `linux-virt` already omits it; we delete defensively in case a future config change pulls it in.
- **`algif_aead`** exposes AEAD crypto to userspace via AF_ALG sockets, used by some crypto libraries to offload to hardware accelerators. The VM has no hardware crypto, so OpenSSL and friends fall back to their software implementations transparently.

## Implementation

`update-kernel` has no module-exclude flag, so we sed-inject a `find … -delete` plus a `depmod` re-run between the apk install of `linux-virt` and the `cp -a` into the modloop staging directory.

Verified absent from `boot/modloop-virt` on both `x86_64` and `aarch64` `std` ISOs; `modules.dep` carries no dangling references.

## Related

Mirrors rancher-desktop commit [`70d168bcc`](https://github.com/jandubois/rancher-desktop/commit/70d168bcc) which removes the same modules from the WSL distro at boot.