### PR TITLE
Revert "Force install kernel from alpine 3.20"

### DIFF
--- a/mkimg.lima.sh
+++ b/mkimg.lima.sh
@@ -83,32 +83,3 @@ profile_lima() {
             apks="$apks zstd"
         fi
 }
-
-# Override build_kernel to use the Alpine 3.20 kernel (6.6) because 6.12 has
-# issues with older Java, https://bugs.openjdk.org/browse/JDK-8348566
-build_kernel() {
-	local _flavor="$2" _modloopsign= _add
-	shift 3
-	local _pkgs="$*"
-	_pkgs=${_pkgs//linux-virt/linux-virt<6.12}
-	[ "$modloop_sign" = "yes" ] && _modloopsign="--modloopsign"
-	echo http://dl-cdn.alpinelinux.org/alpine/v3.20/main > /tmp/repositories.320
-	update-kernel \
-		$_hostkeys \
-		${_abuild_pubkey:+--apk-pubkey $_abuild_pubkey} \
-		$_modloopsign \
-		--verbose \
-		--media \
-		--keys-dir "$APKROOT/etc/apk/keys" \
-		--flavor "$_flavor" \
-		--arch "$ARCH" \
-		--package "$_pkgs" \
-		--feature "$initfs_features" \
-		--modloopfw "$modloopfw" \
-		--repositories-file /tmp/repositories.320 \
-		"$DESTDIR" \
-		|| return 1
-	for _add in $boot_addons; do
-		apk fetch --root "$APKROOT" --quiet --stdout $_add | tar -C "${DESTDIR}" -zx boot/
-	done
-}


### PR DESCRIPTION
Pinning the kernel was a temporary measure to allow JDK based images to update to a fixed version. This happened over 6 months ago.

Ref https://github.com/rancher-sandbox/rancher-desktop/issues/10227

This reverts commit 5bf3edab64993a35ec21cb377b5fea42286b0891.