### PR TITLE
x86_64: rebuild linux-virt with legacy iptables restored

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,14 @@ RUN \
 # Remove --no-chown which is deprecated in apk 3.0 as alias for --usermode (disallowed as root)
 RUN sed -i 's/--initdb --no-chown/--initdb/' /home/build/aports/scripts/mkimage.sh
 
+# On x86_64, rebuild linux-virt with legacy iptables restored (Alpine dropped it
+# there in 3.23 but keeps it on aarch64); needed by containers that ship only the
+# legacy iptables binary, e.g. rancher/rancher.
+# https://github.com/rancher/rancher/issues/54862
+COPY kernel-legacy-iptables.config /home/build/kernel-legacy-iptables.config
+COPY build-legacy-iptables-kernel.sh /home/build/build-legacy-iptables-kernel.sh
+RUN if [ "${ARCH}" = "x86_64" ]; then sh /home/build/build-legacy-iptables-kernel.sh; fi
+
 # Strip kernel modules that are unused in the VM but expose known CVEs
 # (CVE-2026-43284 dirtyfrag esp4/esp6; CVE-2026-43500 dirtyfrag rxrpc;
 # CVE-2026-31431 copy.fail algif_aead). update-kernel has no exclude

--- a/build-legacy-iptables-kernel.sh
+++ b/build-legacy-iptables-kernel.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Rebuild the linux-virt kernel with legacy iptables (xtables) restored.
+#
+# Alpine dropped CONFIG_NETFILTER_XTABLES_LEGACY (and the legacy iptables nat
+# tables/targets) from the x86_64 linux-virt kernel in 3.23, while keeping it on
+# aarch64. The option is built into the kernel image, not available as a loadable
+# module, so the kernel must be rebuilt. Without it, a container that ships only
+# the legacy iptables binary (notably rancher/rancher, whose embedded
+# k3s/kube-proxy uses the legacy backend) cannot create its iptables `nat` table
+# and crashes. See https://github.com/rancher/rancher/issues/54862
+#
+# Only x86_64 needs this; aarch64 keeps Alpine's prebuilt kernel. The rebuilt
+# linux-virt is published into the local package repo that build.sh lists first,
+# so mkimage installs it instead of Alpine's.
+set -eu
+
+ARCH="$(apk --print-arch)"
+KDIR=/home/build/aports/main/linux-lts
+REPO=/home/build/packages/lima
+export REPODEST=/home/build/kernel-packages
+# Build only the virt flavor (skips linux-lts). Exported so checksum and build
+# see the same source list.
+export FLAVOR=virt
+
+cd "$KDIR"
+
+# Append the legacy options to the virt config for this arch.
+cat /home/build/kernel-legacy-iptables.config >> "virt.${ARCH}.config"
+
+# FLAVOR=virt re-adds virt.${ARCH}.config to $source, which the APKBUILD already
+# lists; abuild rejects the duplicate. Drop the original entry so the one FLAVOR
+# adds is the only copy.
+sed -i "/^[[:space:]]*virt\.${ARCH}\.config\$/d" APKBUILD
+
+# Outrank Alpine's prebuilt linux-virt of the same version. The local repo is
+# already listed first in build.sh, but bump pkgrel so the choice is unambiguous.
+# pkgrel does not affect the kernel's vermagic, so out-of-tree modules still match.
+pkgrel="$(awk -F= '/^pkgrel=/{print $2; exit}' APKBUILD)"
+sed -i "s/^pkgrel=.*/pkgrel=$((pkgrel + 100))/" APKBUILD
+
+# The Docker build runs as root, so abuild needs -F. abuild auto-installs the
+# kernel makedepends.
+abuild -F checksum
+abuild -F -r
+
+# Publish into the local repo and re-index it (alongside the openresty/mkcert
+# packages already there).
+mkdir -p "${REPO}/${ARCH}"
+find "${REPODEST}" /root/packages -name 'linux-virt-*.apk' -exec cp {} "${REPO}/${ARCH}/" \;
+cd "${REPO}/${ARCH}"
+apk index -o APKINDEX.tar.gz ./*.apk
+abuild-sign APKINDEX.tar.gz

--- a/kernel-legacy-iptables.config
+++ b/kernel-legacy-iptables.config
@@ -1,0 +1,17 @@
+# Legacy iptables (xtables) netfilter options that Alpine enables on aarch64 but
+# dropped from the x86_64 linux-virt kernel in 3.23. This list is the exact
+# difference between Alpine's virt.aarch64.config and virt.x86_64.config;
+# olddefconfig resolves the remaining framework deps (ip_tables, ip6_tables).
+# See build-legacy-iptables-kernel.sh and rancher/rancher#54862
+CONFIG_NETFILTER_XTABLES_LEGACY=y
+CONFIG_IP_NF_NAT=m
+CONFIG_IP_NF_RAW=m
+CONFIG_IP_NF_TARGET_MASQUERADE=m
+CONFIG_IP_NF_TARGET_NETMAP=m
+CONFIG_IP_NF_TARGET_REDIRECT=m
+CONFIG_IP_NF_TARGET_TTL=m
+CONFIG_IP_NF_ARPFILTER=m
+CONFIG_IP6_NF_NAT=m
+CONFIG_IP6_NF_RAW=m
+CONFIG_IP6_NF_TARGET_MASQUERADE=m
+CONFIG_IP6_NF_TARGET_HL=m


### PR DESCRIPTION
## Why

Alpine dropped `CONFIG_NETFILTER_XTABLES_LEGACY` from the x86_64 `linux-virt`
kernel in 3.23 (kernel 6.17 introduced the switch, off by default) but kept it
on aarch64. Containers that ship only the legacy iptables binary -- notably
`rancher/rancher`, whose embedded k3s/kube-proxy uses the legacy backend --
cannot create their iptables `nat` table and crash with
`can't initialize iptables table 'nat'`. The option is built into the kernel,
not a loadable module, so the only fix is rebuilding the kernel. See
rancher/rancher#54862.

## What

- `kernel-legacy-iptables.config`: the legacy options to restore (the exact
  delta between Alpine's working `virt.aarch64.config` and `virt.x86_64.config`).
- `build-legacy-iptables-kernel.sh`: appends them to `virt.x86_64.config`,
  bumps pkgrel, and rebuilds the `virt` flavor into the local package repo.
- `Dockerfile`: runs the rebuild on x86_64 only. aarch64 keeps Alpine's
  prebuilt kernel, so there is no emulated kernel build.

## Status / needs validation

Draft -- the x86_64 kernel build has not run yet; this PR triggers a CI build.
Points to confirm:
- `FLAVOR=virt abuild -r` builds only linux-virt, not linux-lts.
- `olddefconfig` keeps the appended options and resolves the ip_tables/ip6_tables deps.
- the rebuilt kernel outranks Alpine's in the local repo.
- the added native x86_64 kernel build time is acceptable in CI.

## Test plan

Build the x86_64 ISO, ship it in an RD test build, and run
`bats tests/containers/run-rancher.bats` on an Intel Mac -- it should pass where
it currently fails. Confirm `modprobe iptable_nat` succeeds in the VM.
